### PR TITLE
Add admin JWT auth and protected dashboard

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 fastapi
 uvicorn
+python-jose[cryptography]
+passlib[bcrypt]


### PR DESCRIPTION
Adds a minimal admin authentication flow using JWT tokens (POST /admin/token) and a protected admin dashboard (GET /admin/dashboard). Also updates `requirements.txt` and documents env vars in `src/README.md`. This is intended as a development convenience; rotate credentials and supply a secure `SECRET_KEY` before production.